### PR TITLE
Add package initializer for uav

### DIFF
--- a/uav/__init__.py
+++ b/uav/__init__.py
@@ -1,0 +1,19 @@
+"""UAV package providing perception, navigation and interface utilities."""
+
+from .perception import OpticalFlowTracker, FlowHistory
+from .navigation import Navigator
+from .interface import exit_flag, start_gui
+from .utils import apply_clahe, get_yaw, get_speed, get_drone_state
+
+__all__ = [
+    "OpticalFlowTracker",
+    "FlowHistory",
+    "Navigator",
+    "exit_flag",
+    "start_gui",
+    "apply_clahe",
+    "get_yaw",
+    "get_speed",
+    "get_drone_state",
+]
+


### PR DESCRIPTION
## Summary
- add `uav/__init__.py` to expose UAV utilities as a package

## Testing
- `python -m py_compile uav/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6840abd2639c8325877bc397b092241d