### PR TITLE
Add UE4 path option

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -47,11 +47,12 @@ AirSimExperiments/
 ## Running the Simulation
 
 1. Launch the AirSim Unreal environment.
-2. Run the script:
+2. Run the script. You can override the path to the Unreal Engine executable using `--ue4-path`:
 
    ```bash
-   python main.py
+   python main.py --ue4-path "C:\\Path\\To\\Blocks.exe"
    ```
+   If omitted, the path defaults to the value used during development.
 3. Click the GUI stop button to end the simulation cleanly.
 
 ## Example Log Format

--- a/main.py
+++ b/main.py
@@ -8,8 +8,13 @@ import subprocess
 import math
 from airsim import ImageRequest, ImageType
 import argparse
+
+# Default path to the Unreal Engine simulator used during development
+DEFAULT_UE4_PATH = r"C:\Users\newso\Documents\AirSimExperiments\BlocksBuild\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe"
+
 parser = argparse.ArgumentParser(description="Optical flow navigation script")
 parser.add_argument("--manual-nudge", action="store_true", help="Enable manual nudge at frame 5 for testing")
+parser.add_argument("--ue4-path", default=DEFAULT_UE4_PATH, help="Path to the Unreal Engine executable")
 args = parser.parse_args()
 
 from uav.interface import exit_flag, start_gui
@@ -33,7 +38,7 @@ param_refs = {
 start_gui(param_refs)
 
 # === LAUNCH UE4 SIMULATION ===
-ue4_exe = r"C:\Users\newso\Documents\AirSimExperiments\BlocksBuild\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe"
+ue4_exe = args.ue4_path
 try:
     sim_process = subprocess.Popen([ue4_exe, "-windowed", "-ResX=1280", "-ResY=720"])
     print("Launching Unreal Engine simulation...")


### PR DESCRIPTION
## Summary
- add `--ue4-path` option to override simulator path
- document the option in the README
- use the provided path when launching UE4

## Testing
- `python -m py_compile main.py uav/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b19d8bb88325b167d4078e7642e9