### PR TITLE
Remove unused probe threshold assignment

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,7 +168,6 @@ try:
             pos, yaw, speed = get_drone_state(client)
             brake_thres = 35 + 15 * speed
             dodge_thres = 5 + 3 * speed
-            probe_req = 15 + 3 * speed
 
             center_high = smooth_C > dodge_thres
             side_diff = abs(smooth_L - smooth_R)


### PR DESCRIPTION
## Summary
- clean up `main.py` by removing an unused probe flow threshold variable

## Testing
- `python -m py_compile main.py uav/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b1b389c08325bec43636068a9b89