### PR TITLE
Add FlowHistory tests and update README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -44,6 +44,15 @@ AirSimExperiments/
 * OpenCV (`pip install opencv-python`)
 * NumPy (`pip install numpy`)
 
+## Running Tests
+
+The unit tests use [pytest](https://pytest.org/). After installing the
+requirements, run the tests from the project root:
+
+```bash
+pytest
+```
+
 ## Running the Simulation
 
 1. Launch the AirSim Unreal environment.

--- a/tests/test_flow_history.py
+++ b/tests/test_flow_history.py
@@ -1,0 +1,28 @@
+import numpy as np
+from uav.perception import FlowHistory
+
+
+def test_window_size_and_update():
+    fh = FlowHistory(size=3)
+    fh.update(1, 2, 3)
+    fh.update(4, 5, 6)
+    fh.update(7, 8, 9)
+    assert len(fh.window) == 3
+
+    fh.update(10, 11, 12)
+    assert len(fh.window) == 3
+    assert np.allclose(fh.window[0], np.array([4, 5, 6]))
+    assert np.allclose(fh.window[-1], np.array([10, 11, 12]))
+
+
+def test_average_values():
+    fh = FlowHistory(size=3)
+    fh.update(1, 2, 3)
+    fh.update(4, 5, 6)
+    fh.update(7, 8, 9)
+    avg = fh.average()
+    assert np.allclose(avg, (4.0, 5.0, 6.0))
+
+    fh.update(10, 11, 12)
+    avg = fh.average()
+    assert np.allclose(avg, (7.0, 8.0, 9.0))


### PR DESCRIPTION
## Summary
- test FlowHistory's update window and averaging
- document how to run tests with `pytest`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840b1c5a0a0832599c0b412e57b1942