### PR TITLE
Add Navigator tests with AirSim mock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import types
+
+# Minimal numpy stub for environments without numpy
+class DummyArray(list):
+    def mean(self, axis=None):
+        if axis is None:
+            return sum(self) / len(self)
+        cols = list(zip(*self))
+        return DummyArray([sum(c) / len(c) for c in cols])
+
+
+def array(obj):
+    if isinstance(obj, DummyArray):
+        return obj
+    return DummyArray(list(obj))
+
+
+def allclose(a, b, tol=1e-8):
+    a_list = list(a)
+    b_list = list(b)
+    if len(a_list) != len(b_list):
+        return False
+    return all(abs(x - y) <= tol for x, y in zip(a_list, b_list))
+
+
+numpy_stub = types.SimpleNamespace(array=array, allclose=allclose)
+
+# Register stub if numpy is missing
+if 'numpy' not in sys.modules:
+    sys.modules['numpy'] = numpy_stub
+# Minimal cv2 stub for environments without OpenCV
+if "cv2" not in sys.modules:
+    cv2_stub = types.SimpleNamespace(
+        createCLAHE=lambda **kwargs: types.SimpleNamespace(apply=lambda img: img),
+        goodFeaturesToTrack=lambda *a, **k: None,
+        calcOpticalFlowPyrLK=lambda *a, **k: (None, None, None)
+    )
+    sys.modules["cv2"] = cv2_stub
+# Minimal airsim stub for environments without AirSim
+class DummyYawMode:
+    def __init__(self, is_rate, yaw_or_rate):
+        self.is_rate = is_rate
+        self.yaw_or_rate = yaw_or_rate
+
+airsim_stub = types.SimpleNamespace(
+    DrivetrainType=types.SimpleNamespace(ForwardOnly=1),
+    YawMode=DummyYawMode,
+    to_eularian_angles=lambda ori: (0, 0, 0),
+)
+if "airsim" not in sys.modules:
+    sys.modules["airsim"] = airsim_stub
+

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,0 +1,111 @@
+import unittest.mock as mock
+from tests.conftest import airsim_stub
+
+from uav.navigation import Navigator
+
+
+class DummyFuture:
+    def __init__(self):
+        self.join_called = False
+
+    def join(self):
+        self.join_called = True
+
+
+class DummyClient:
+    def __init__(self):
+        self.moveByVelocityAsync = mock.MagicMock(side_effect=self._moveByVelocityAsync)
+        self.moveByVelocityBodyFrameAsync = mock.MagicMock(side_effect=self._moveByVelocityBodyFrameAsync)
+        self.calls = []
+
+    def _moveByVelocityAsync(self, *args, **kwargs):
+        fut = DummyFuture()
+        self.calls.append(('moveByVelocityAsync', args, kwargs, fut))
+        return fut
+
+    def _moveByVelocityBodyFrameAsync(self, *args, **kwargs):
+        fut = DummyFuture()
+        self.calls.append(('moveByVelocityBodyFrameAsync', args, kwargs, fut))
+        return fut
+
+
+def test_brake_updates_flags_and_calls():
+    client = DummyClient()
+    nav = Navigator(client)
+    prev = nav.last_movement_time
+    result = nav.brake()
+    assert result == 'brake'
+    assert nav.braked is True
+    assert nav.dodging is False
+    assert nav.last_movement_time == prev
+    name, args, kwargs, fut = client.calls[-1]
+    assert name == 'moveByVelocityAsync'
+    assert args == (0, 0, 0, 1)
+    assert fut.join_called is True
+
+
+def test_dodge_left_sets_flags_and_calls():
+    client = DummyClient()
+    nav = Navigator(client)
+    prev = nav.last_movement_time
+    result = nav.dodge(0, 0, 20)
+    assert result == 'dodge_left'
+    assert nav.braked is False
+    assert nav.dodging is True
+    assert nav.last_movement_time > prev
+    assert client.moveByVelocityBodyFrameAsync.call_count == 2
+    call1 = client.moveByVelocityBodyFrameAsync.call_args_list[0]
+    assert call1.args == (0, 0, 0, 0.2)
+    call2 = client.moveByVelocityBodyFrameAsync.call_args_list[1]
+    assert call2.args == (0.3, -1.0, 0, 2.0)
+    fut1 = client.calls[0][3]
+    fut2 = client.calls[1][3]
+    assert fut1.join_called is True
+    assert fut2.join_called is True
+
+
+def test_resume_forward_clears_flags_and_calls():
+    client = DummyClient()
+    nav = Navigator(client)
+    prev = nav.last_movement_time
+    result = nav.resume_forward()
+    assert result == 'resume'
+    assert nav.braked is False
+    assert nav.dodging is False
+    assert nav.last_movement_time > prev
+    client.moveByVelocityAsync.assert_called_once()
+    args, kwargs = client.moveByVelocityAsync.call_args
+    assert args[:3] == (2, 0, 0)
+    assert kwargs.get('duration') == 3
+    assert kwargs.get('drivetrain') == airsim_stub.DrivetrainType.ForwardOnly
+
+
+def test_nudge_updates_time_and_calls():
+    client = DummyClient()
+    nav = Navigator(client)
+    prev = nav.last_movement_time
+    result = nav.nudge()
+    assert result == 'nudge'
+    assert nav.braked is False
+    assert nav.dodging is False
+    assert nav.last_movement_time > prev
+    name, args, kwargs, fut = client.calls[-1]
+    assert name == 'moveByVelocityAsync'
+    assert args == (0.5, 0, 0, 1)
+    assert fut.join_called is True
+
+
+def test_reinforce_updates_time_and_calls():
+    client = DummyClient()
+    nav = Navigator(client)
+    prev = nav.last_movement_time
+    result = nav.reinforce()
+    assert result == 'resume_reinforce'
+    assert nav.braked is False
+    assert nav.dodging is False
+    assert nav.last_movement_time > prev
+    client.moveByVelocityAsync.assert_called_once()
+    args, kwargs = client.moveByVelocityAsync.call_args
+    assert args[:3] == (2, 0, 0)
+    assert kwargs.get('duration') == 3
+    assert kwargs.get('drivetrain') == airsim_stub.DrivetrainType.ForwardOnly


### PR DESCRIPTION
## Summary
- add minimal stubs for numpy, cv2 and airsim in test config
- implement new tests for Navigator behavior using a dummy AirSim client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b7bf373083258fb7cf1c3fe2dd04