### PR TITLE
Add time limit to UAV simulation

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,6 +70,7 @@ navigator = Navigator(client)
 
 frame_count = 0
 start_time = time.time()
+MAX_SIM_DURATION = 30  # seconds
 timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 os.makedirs("flow_logs", exist_ok=True)
 log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')
@@ -98,6 +99,9 @@ try:
         frame_count += 1
         loop_start = time.time()
         time_now = time.time()  # <-- Add this line
+        if time_now - start_time >= MAX_SIM_DURATION:
+            print("⏱️ Time limit reached — landing and stopping.")
+            break
 
         # --- Get image from AirSim ---
         t0 = time.time()


### PR DESCRIPTION
## Summary
- add a constant for the maximum simulation time
- break the main loop and land when 30 seconds have elapsed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bac5b290832582f941a9d7dfbdef