### PR TITLE
Improve dodge logic for ambiguous walls

### DIFF
--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -64,6 +64,18 @@ def test_dodge_left_sets_flags_and_calls():
     assert fut2.join_called is True
 
 
+def test_ambiguous_dodge_forces_lower_flow_side():
+    client = DummyClient()
+    nav = Navigator(client)
+    result = nav.dodge(30, 3.0, 32)
+    assert result == 'dodge_left'
+    assert client.moveByVelocityBodyFrameAsync.call_count == 2
+    call1 = client.moveByVelocityBodyFrameAsync.call_args_list[0]
+    assert call1.args == (0, 0, 0, 0.2)
+    call2 = client.moveByVelocityBodyFrameAsync.call_args_list[1]
+    assert call2.args == (0.0, -1.0, 0, 2.0)
+
+
 def test_resume_forward_clears_flags_and_calls():
     client = DummyClient()
     nav = Navigator(client)

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -31,11 +31,20 @@ class Navigator:
         return "brake"
 
     def dodge(self, smooth_L, smooth_C, smooth_R):
-        """Perform a lateral dodge based on flow magnitudes."""
-        if smooth_L < smooth_R - 10:
+        """Perform a lateral dodge based on flow magnitudes.
+
+        If the difference between left and right flow values is small but the
+        center flow is high, force a dodge toward the slightly safer side
+        instead of skipping.
+        """
+        if smooth_L + 10 < smooth_R:
             direction = "left"
-        elif smooth_R < smooth_L - 10:
+        elif smooth_R + 10 < smooth_L:
             direction = "right"
+        elif smooth_C > 1.0:
+            # flat wall straight ahead – pick the lower flow side
+            direction = "left" if smooth_L <= smooth_R else "right"
+            print(f"⚠️ Ambiguous dodge -> forcing {direction}")
         else:
             print("❌ Dodge ambiguous — skipping")
             return "no_dodge"


### PR DESCRIPTION
## Summary
- improve `Navigator.dodge` to force a direction when left/right flow is similar but forward flow is high
- cover the new behaviour in the navigator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bcbae898832589b4bbd6a7ba3c76