### PR TITLE
Remove unused parameter from process_frame

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ try:
             client.moveByVelocityAsync(2, 0, 0, 2).join()
 
         # --- Optical flow processing ---
-        good_old, flow_vectors, flow_std = tracker.process_frame(gray, start_time)
+        good_old, flow_vectors, flow_std = tracker.process_frame(gray)
         magnitudes = np.linalg.norm(flow_vectors, axis=1)
         h, w = gray.shape
         good_old = good_old.reshape(-1, 2)  # Ensure proper shape

--- a/uav/perception.py
+++ b/uav/perception.py
@@ -39,7 +39,7 @@ class OpticalFlowTracker:
         self.prev_pts = cv2.goodFeaturesToTrack(gray_frame, mask=None, **self.feature_params)
         self.prev_time = time.time()
 
-    def process_frame(self, gray, _unused_start_time):  # ignore external time
+    def process_frame(self, gray):
         """Track features in *gray* and return vectors with standard deviation."""
         if self.prev_gray is None or self.prev_pts is None:
             self.initialize(gray)


### PR DESCRIPTION
## Summary
- simplify `process_frame` in `uav/perception` by removing the unused `_unused_start_time` argument
- update call site in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bde80bf08325b9e8aa36ed722b25