### PR TITLE
Track image and decode times

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -73,8 +73,8 @@ pytest
 ## Example Log Format
 
 ```
-frame,time,features,flow_left,flow_center,flow_right,flow_std,pos_x,pos_y,pos_z,yaw,speed,state,collided,brake_thres,dodge_thres,probe_req,fps
-1,0.05,120,3.2,1.1,2.0,0.8,0.12,0.00,-2.00,0.0,1.7,resume,0,50.0,8.0,20.0,18.5
+frame,time,features,flow_left,flow_center,flow_right,flow_std,pos_x,pos_y,pos_z,yaw,speed,state,collided,brake_thres,dodge_thres,probe_req,fps,simgetimage_s,decode_s,processing_s,loop_s
+1,0.05,120,3.2,1.1,2.0,0.8,0.12,0.00,-2.00,0.0,1.7,resume,0,50.0,8.0,20.0,18.5,0.03,0.01,0.00,0.06
 ```
 
 ## Future Improvements

--- a/main.py
+++ b/main.py
@@ -104,18 +104,23 @@ try:
             break
 
         # --- Get image from AirSim ---
+        # Capture image from the simulator
         t0 = time.time()
         responses = client.simGetImages([
             ImageRequest("oakd_camera", ImageType.Scene, False, True)  # compress=True for JPEG
         ])
+        t1 = time.time()  # after simGetImages
         response = responses[0]
         if response.width == 0 or response.height == 0 or len(response.image_data_uint8) == 0:
             out.write(last_vis_img)
             continue
 
         img1d = np.frombuffer(response.image_data_uint8, dtype=np.uint8)
+        t2 = time.time()  # before decoding JPEG
         img = cv2.imdecode(img1d, cv2.IMREAD_COLOR)
-        t1 = time.time()
+        t3 = time.time()  # after decoding
+        simgetimage_s = t1 - t0
+        decode_s = t3 - t2
         if img is None:
             out.write(last_vis_img)
             continue
@@ -271,7 +276,7 @@ try:
             f"{smooth_L:.3f},{smooth_C:.3f},{smooth_R:.3f},{flow_std:.3f},"
             f"{pos.x_val:.2f},{pos.y_val:.2f},{pos.z_val:.2f},{yaw:.2f},{speed:.2f},{state_str},{collided},"
             f"{brake_thres:.2f},{dodge_thres:.2f},{probe_req:.2f},{actual_fps:.2f},"
-            f"{t1-t0:.3f},{t1-t0:.3f},0.0,{time.time()-loop_start:.3f}\n"
+            f"{simgetimage_s:.3f},{decode_s:.3f},0.0,{time.time()-loop_start:.3f}\n"
         )
 
         print(f"Actual FPS: {actual_fps:.2f}")


### PR DESCRIPTION
## Summary
- track time for `client.simGetImages` separately from JPEG decode
- log the separate durations
- document updated CSV header in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bde8994883259b3afc6fa13fb0e7