### PR TITLE
Add test for retain_recent_logs

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import os
+import time
+from uav.utils import retain_recent_logs
+
+
+def test_retain_recent_logs_keeps_latest(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    now = time.time()
+    paths = []
+    for i in range(5):
+        p = log_dir / f"log_{i}.csv"
+        p.write_text("data")
+        mod_time = now - i
+        os.utime(p, (mod_time, mod_time))
+        paths.append(p)
+
+    retain_recent_logs(str(log_dir), keep=3)
+    remaining = sorted(f.name for f in log_dir.iterdir())
+    assert remaining == ["log_0.csv", "log_1.csv", "log_2.csv"]
+
+
+def test_retain_recent_logs_missing_dir(tmp_path):
+    missing = tmp_path / "missing"
+    retain_recent_logs(str(missing), keep=3)
+    assert not missing.exists()
+


### PR DESCRIPTION
## Summary
- verify retain_recent_logs keeps only newest csv files
- check that missing directories are silently ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bde960fc8325a77ffcdf4c074b49