### PR TITLE
Use default FlowHistory size

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def main():
                      criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 0.03))
 
     tracker = OpticalFlowTracker(lk_params, feature_params)
-    flow_history = FlowHistory(size=5)
+    flow_history = FlowHistory()
     navigator = Navigator(client)
     from collections import deque
     state_history = deque(maxlen=3)
@@ -249,7 +249,7 @@ def main():
                     print("Reset error:", e)
 
                 tracker.initialize(gray)
-                flow_history = FlowHistory(size=5)
+                flow_history = FlowHistory()
                 navigator = Navigator(client)
                 frame_count = 0
                 param_refs['reset_flag'][0] = False


### PR DESCRIPTION
## Summary
- let FlowHistory use its default window size of 10 in main
- same change applied when resetting simulation
- tests remain green

## Testing
- `pytest -q tests/test_flow_history.py tests/test_navigator.py tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684149fa4de08325bfbb00004f8976c8