### PR TITLE
Extend simulation runtime to 60 seconds

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def main():
 
     frame_count = 0
     start_time = time.time()
-    MAX_SIM_DURATION = 30  # seconds
+    MAX_SIM_DURATION = 60  # seconds
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     os.makedirs("flow_logs", exist_ok=True)
     log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')


### PR DESCRIPTION
## Summary
- bump MAX_SIM_DURATION from 30 to 60 seconds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68415024f0a88325b73142201d0777fc