### PR TITLE
Add run summarization tool

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -88,6 +88,18 @@ frame,time,features,flow_left,flow_center,flow_right,flow_std,pos_x,pos_y,pos_z,
 1,0.05,120,3.2,1.1,2.0,0.8,0.12,0.00,-2.00,0.0,1.7,resume,0,50.0,8.0,20.0,18.5
 ```
 
+## Summarizing Runs
+
+Gather quick statistics about each run with:
+
+```bash
+python analysis/summarize_runs.py
+```
+
+The script scans `flow_logs/full_log_*.csv` and prints the frame count,
+how many frames registered a collision, and the straight‑line distance
+from the first to the last recorded position.
+
 ## Future Improvements
 
 * Add SLAM integration

--- a/analysis/summarize_runs.py
+++ b/analysis/summarize_runs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Summarize flow log CSV files.
+
+This script scans ``flow_logs`` for files named ``full_log_*.csv`` and
+prints basic statistics for each run: total frame count, the number of
+frames with a collision, and the straight‑line distance traveled from
+the first to the last recorded position.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def summarize_log(path: str) -> Tuple[int, int, float]:
+    """Return summary statistics for a log file.
+
+    Args:
+        path: Path to a ``full_log_*.csv`` file.
+
+    Returns:
+        ``(frames, collisions, distance)`` where ``frames`` is the
+        number of rows in the CSV, ``collisions`` counts how many rows
+        have ``collided`` > 0, and ``distance`` is the Euclidean
+        distance between the first and last ``(pos_x, pos_y, pos_z)``
+        entries.
+    """
+    df = pd.read_csv(path)
+
+    frames = len(df)
+    collisions = int((df.get("collided", 0) > 0).sum())
+
+    start = df.loc[0, ["pos_x", "pos_y", "pos_z"]].to_numpy()
+    end = df.loc[df.index[-1], ["pos_x", "pos_y", "pos_z"]].to_numpy()
+    distance = float(np.linalg.norm(end - start))
+
+    return frames, collisions, distance
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Summarize UAV run logs")
+    parser.add_argument(
+        "--log-dir",
+        default="flow_logs",
+        help="Directory containing full_log_*.csv files",
+    )
+    args = parser.parse_args()
+
+    pattern = os.path.join(args.log_dir, "full_log_*.csv")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        print(f"No log files found matching {pattern}")
+        return
+
+    for path in files:
+        try:
+            frames, collisions, distance = summarize_log(path)
+            name = os.path.basename(path)
+            print(
+                f"{name}: frames={frames}, collisions={collisions}, "
+                f"distance={distance:.2f}"
+            )
+        except Exception as exc:
+            print(f"Error processing {path}: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `analysis/summarize_runs.py` for simple log statistics
- document how to use the summarization script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684194c52b788325a00d1a61da0d2ddd