### PR TITLE
Clean up old flight_view logs

### DIFF
--- a/analysis/visualize_flight.py
+++ b/analysis/visualize_flight.py
@@ -3,7 +3,9 @@ import json
 import numpy as np
 import argparse
 import plotly.graph_objects as go
+import os
 from scipy.spatial.transform import Rotation as R
+from uav.utils import retain_recent_views
 
 
 def load_telemetry(log_path):
@@ -198,6 +200,7 @@ def main():
     fig = build_plot(telemetry, obstacles, offset, scale=args.scale)
     fig.write_html(args.output)
     print(f"✅ Visualization saved to {args.output}")
+    retain_recent_views(os.path.dirname(args.output))
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -31,7 +31,11 @@ def main():
     from uav.interface import exit_flag, start_gui
     from uav.perception import OpticalFlowTracker, FlowHistory
     from uav.navigation import Navigator
-    from uav.utils import get_drone_state, retain_recent_logs
+    from uav.utils import (
+        get_drone_state,
+        retain_recent_logs,
+        retain_recent_views,
+    )
 
     # GUI parameter and status holders
     param_refs = {
@@ -86,6 +90,7 @@ def main():
         "brake_thres,dodge_thres,probe_req,fps,simgetimage_s,decode_s,processing_s,loop_s\n"
     )
     retain_recent_logs("flow_logs")
+    retain_recent_views("analysis")
 
     # Video writer setup
     fourcc = cv2.VideoWriter_fourcc(*'MJPG')
@@ -294,6 +299,7 @@ def main():
                     "brake_thres,dodge_thres,probe_req,fps,simgetimage_s,decode_s,processing_s,loop_s\n"
                 )
                 retain_recent_logs("flow_logs")
+                retain_recent_views("analysis")
 
                 # === Reset video writer ===
                 frame_queue.put(None)
@@ -367,6 +373,7 @@ def main():
                 "--scale", "1.0"
             ])
             print(f"✅ 3D visualisation saved to {html_output}")
+            retain_recent_views("analysis")
         except Exception as e:
             print(f"⚠️ Visualization failed: {e}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import os
 import time
-from uav.utils import retain_recent_logs
+from uav.utils import retain_recent_logs, retain_recent_views
 
 
 def test_retain_recent_logs_keeps_latest(tmp_path):
@@ -24,5 +24,33 @@ def test_retain_recent_logs_keeps_latest(tmp_path):
 def test_retain_recent_logs_missing_dir(tmp_path):
     missing = tmp_path / "missing"
     retain_recent_logs(str(missing), keep=3)
+    assert not missing.exists()
+
+
+def test_retain_recent_views_keeps_latest(tmp_path):
+    analysis_dir = tmp_path / "analysis"
+    analysis_dir.mkdir()
+
+    now = time.time()
+    for i in range(6):
+        p = analysis_dir / f"flight_view_{i}.html"
+        p.write_text("html")
+        mod_time = now - i
+        os.utime(p, (mod_time, mod_time))
+
+    retain_recent_views(str(analysis_dir), keep=5)
+    remaining = sorted(f.name for f in analysis_dir.iterdir())
+    assert remaining == [
+        "flight_view_0.html",
+        "flight_view_1.html",
+        "flight_view_2.html",
+        "flight_view_3.html",
+        "flight_view_4.html",
+    ]
+
+
+def test_retain_recent_views_missing_dir(tmp_path):
+    missing = tmp_path / "missing"
+    retain_recent_views(str(missing), keep=5)
     assert not missing.exists()
 

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -53,3 +53,32 @@ def retain_recent_logs(log_dir: str, keep: int = 5) -> None:
             os.remove(old_log)
         except OSError:
             pass
+
+
+def retain_recent_views(analysis_dir: str, keep: int = 5) -> None:
+    """Remove old flight view HTML files leaving only the newest ``keep``.
+
+    Parameters
+    ----------
+    analysis_dir: str
+        Directory containing ``flight_view_*.html`` files.
+    keep: int, optional
+        Number of most recent files to keep. Defaults to 5.
+    """
+
+    try:
+        views = [
+            os.path.join(analysis_dir, f)
+            for f in os.listdir(analysis_dir)
+            if f.startswith("flight_view_") and f.endswith(".html")
+        ]
+    except FileNotFoundError:
+        return
+
+    views.sort(key=os.path.getmtime, reverse=True)
+
+    for old_view in views[keep:]:
+        try:
+            os.remove(old_view)
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary
- keep only the latest 5 flight view files
- add tests for pruning old visualizations

## Testing
- `pip install opencv-python msgpack-rpc-python msgpack pandas plotly scipy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841989397008325a7b795335035749e