### PR TITLE
Add summarize_log tests and handle missing collisions

### DIFF
--- a/analysis/summarize_runs.py
+++ b/analysis/summarize_runs.py
@@ -34,7 +34,10 @@ def summarize_log(path: str) -> Tuple[int, int, float]:
     df = pd.read_csv(path)
 
     frames = len(df)
-    collisions = int((df.get("collided", 0) > 0).sum())
+    if "collided" in df.columns:
+        collisions = int((df["collided"] > 0).sum())
+    else:
+        collisions = 0
 
     start = df.loc[0, ["pos_x", "pos_y", "pos_z"]].to_numpy()
     end = df.loc[df.index[-1], ["pos_x", "pos_y", "pos_z"]].to_numpy()

--- a/tests/test_summarize_runs.py
+++ b/tests/test_summarize_runs.py
@@ -1,0 +1,39 @@
+import sys
+if "numpy" in sys.modules:
+    del sys.modules["numpy"]
+import numpy as np
+sys.modules["numpy"] = np
+import csv
+import math
+import pytest
+from analysis.summarize_runs import summarize_log
+
+
+def test_summarize_log_basic(tmp_path):
+    path = tmp_path / "log.csv"
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["pos_x", "pos_y", "pos_z", "collided"])
+        writer.writeheader()
+        writer.writerow({"pos_x": 0, "pos_y": 0, "pos_z": 0, "collided": 0})
+        writer.writerow({"pos_x": 1, "pos_y": 0, "pos_z": 0, "collided": 1})
+        writer.writerow({"pos_x": 2, "pos_y": 0, "pos_z": 0, "collided": 0})
+
+    frames, collisions, distance = summarize_log(str(path))
+    assert frames == 3
+    assert collisions == 1
+    assert distance == pytest.approx(2.0)
+
+
+def test_summarize_log_missing_collided(tmp_path):
+    path = tmp_path / "log.csv"
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["pos_x", "pos_y", "pos_z"])
+        writer.writeheader()
+        writer.writerow({"pos_x": 0, "pos_y": 0, "pos_z": 0})
+        writer.writerow({"pos_x": 0, "pos_y": 1, "pos_z": 1})
+
+    frames, collisions, distance = summarize_log(str(path))
+    assert frames == 2
+    assert collisions == 0
+    expected = math.sqrt(2)
+    assert distance == pytest.approx(expected)

--- a/tests/test_visualize_flight.py
+++ b/tests/test_visualize_flight.py
@@ -2,10 +2,13 @@ import sys
 import types
 import pytest
 # Replace potential numpy stub from conftest with the real package
-if "numpy" in sys.modules:
+if "numpy" in sys.modules and getattr(sys.modules["numpy"], "__file__", None) is None:
     del sys.modules["numpy"]
-import numpy as real_numpy
-sys.modules["numpy"] = real_numpy
+if "numpy" in sys.modules:
+    real_numpy = sys.modules["numpy"]
+else:
+    import numpy as real_numpy
+    sys.modules["numpy"] = real_numpy
 
 # Provide minimal stubs if optional deps are missing
 if 'pandas' not in sys.modules:


### PR DESCRIPTION
## Summary
- add a regression test for `summarize_log`
- fix `summarize_log` when `collided` column is missing
- avoid reloading numpy in visualization tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419ab25aa48325866036af482733c1