### PR TITLE
Add review_runs script

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,1 +1,5 @@
+"""Analysis utilities for reviewing UAV runs."""
 
+from .summarize_runs import summarize_log
+
+__all__ = ["summarize_log"]

--- a/analysis/review_runs.py
+++ b/analysis/review_runs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Review and visualize UAV run logs."""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+from typing import List, Tuple
+
+# Use absolute import so the script works when executed directly
+import sys
+
+# Ensure the repository root is on sys.path when executed directly
+if __package__ is None:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from analysis.summarize_runs import summarize_log
+
+
+def ensure_visualization(log_path: str, html_path: str) -> None:
+    """Generate a flight visualization if ``html_path`` does not exist."""
+    if os.path.exists(html_path):
+        return
+
+    cmd = [
+        "python",
+        os.path.join("analysis", "visualize_flight.py"),
+        "--log",
+        log_path,
+        "--obstacles",
+        os.path.join("analysis", "obstacles.json"),
+        "--output",
+        html_path,
+    ]
+    subprocess.run(cmd, check=False)
+
+
+def main() -> None:
+    pattern = os.path.join("flow_logs", "full_log_*.csv")
+    logs = sorted(glob.glob(pattern))
+    if not logs:
+        print(f"No log files found matching {pattern}")
+        return
+
+    results: List[Tuple[str, int, int, float]] = []
+
+    for path in logs:
+        try:
+            frames, collisions, distance = summarize_log(path)
+            results.append((path, frames, collisions, distance))
+        except Exception as exc:
+            print(f"Error processing {path}: {exc}")
+            continue
+
+        timestamp = os.path.basename(path)[len("full_log_"):-len(".csv")]
+        html_name = f"flight_view_{timestamp}.html"
+        html_path = os.path.join("analysis", html_name)
+        ensure_visualization(path, html_path)
+
+    report_lines = ["log,frames,collisions,distance"]
+    for path, frames, collisions, distance in results:
+        name = os.path.basename(path)
+        report_lines.append(f"{name},{frames},{collisions},{distance:.2f}")
+
+    report_path = os.path.join("analysis", "summary_report.txt")
+    with open(report_path, "w") as fh:
+        fh.write("\n".join(report_lines))
+    print(f"Summary written to {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/summary_report.txt
+++ b/analysis/summary_report.txt
@@ -1,0 +1,6 @@
+log,frames,collisions,distance
+full_log_20250605_132004.csv,170,35,10.95
+full_log_20250605_132105.csv,214,61,12.48
+full_log_20250605_132205.csv,168,51,8.67
+full_log_20250605_132316.csv,154,31,8.41
+full_log_20250605_132413.csv,200,42,13.16


### PR DESCRIPTION
## Summary
- export `summarize_log` in `analysis.__init__`
- generate a summary of all `full_log_*.csv` files and optional visualizations in `review_runs.py`
- include a sample generated summary report

## Testing
- `pip install numpy pandas plotly scipy`
- `pytest -q`
- `python analysis/review_runs.py`

------
https://chatgpt.com/codex/tasks/task_e_68419aa9e9f88325af7a07f3e36c5bcf