### PR TITLE
Add flow variance check for fallback dodge

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -88,6 +88,13 @@ frame,time,features,flow_left,flow_center,flow_right,flow_std,pos_x,pos_y,pos_z,
 1,0.05,120,3.2,1.1,2.0,0.8,0.12,0.00,-2.00,0.0,1.7,resume,0,50.0,8.0,20.0,18.5
 ```
 
+## Parameters
+
+`FLOW_STD_MAX` controls the maximum tolerated variance of optical flow
+magnitudes. When the standard deviation reported by the tracker exceeds
+this threshold the probe-based fallback dodge logic is skipped because
+the motion estimate is unreliable. The default value is `10.0`.
+
 ## Summarizing Runs
 
 Gather quick statistics about each run with:

--- a/main.py
+++ b/main.py
@@ -78,6 +78,7 @@ def main():
     start_time = time.time()
     MAX_SIM_DURATION = 60  # seconds
     MIN_PROBE_FEATURES = 5
+    FLOW_STD_MAX = 10.0
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     os.makedirs("flow_logs", exist_ok=True)
     log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')
@@ -237,7 +238,7 @@ def main():
                     state_str = navigator.dodge(smooth_L, smooth_C, smooth_R)
                 # Fallback: high center flow and low probe => flat wall straight ahead
                 elif probe_mag < 0.5 and center_mag > 0.7:
-                    if should_flat_wall_dodge(center_mag, probe_mag, probe_count, MIN_PROBE_FEATURES):
+                    if should_flat_wall_dodge(center_mag, probe_mag, probe_count, MIN_PROBE_FEATURES, flow_std, FLOW_STD_MAX):
                         print("🟥 Flat wall detected — attempting fallback dodge")
                         state_str = navigator.dodge(smooth_L, smooth_C, smooth_R)
                     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,3 +32,8 @@ def test_should_flat_wall_dodge_threshold():
     # Not enough probe features -> should be False
     assert should_flat_wall_dodge(1.0, 0.2, 3, 5) is False
 
+
+def test_should_flat_wall_dodge_flow_std_limit():
+    # Excessive variance should disable the fallback dodge
+    assert should_flat_wall_dodge(1.0, 0.2, 5, 5, flow_std=50.0) is False
+

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -6,6 +6,10 @@ import numpy as np
 import airsim
 import os
 
+# Maximum acceptable standard deviation of optical flow magnitudes. When the
+# measured value exceeds this threshold the flow is considered unreliable.
+FLOW_STD_MAX = 10.0
+
 def apply_clahe(gray_image):
     """Improve contrast of a grayscale image using CLAHE."""
     clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
@@ -56,10 +60,33 @@ def retain_recent_logs(log_dir: str, keep: int = 5) -> None:
 
 
 def should_flat_wall_dodge(center_mag: float, probe_mag: float, probe_count: int,
-                           min_probe_features: int = 5) -> bool:
+                           min_probe_features: int = 5,
+                           flow_std: float = 0.0,
+                           std_threshold: float = FLOW_STD_MAX) -> bool:
     """Return True when probe flow is low but has enough features to
-    confidently interpret a flat wall straight ahead."""
+    confidently interpret a flat wall straight ahead.
+
+    Parameters
+    ----------
+    center_mag : float
+        Averaged flow magnitude in the central region.
+    probe_mag : float
+        Flow magnitude in the upper center "probe" band.
+    probe_count : int
+        Number of tracked features in the probe region.
+    min_probe_features : int, optional
+        Required feature count to consider the probe reliable.
+    flow_std : float, optional
+        Standard deviation of all tracked flow magnitudes for the current frame.
+    std_threshold : float, optional
+        Maximum allowed standard deviation before the flow is deemed unreliable.
+    """
+
+    if flow_std > std_threshold:
+        # Optical flow is noisy – skip this heuristic
+        return False
 
     if probe_count < min_probe_features:
         return False
+
     return probe_mag < 0.5 and center_mag > 0.7


### PR DESCRIPTION
## Summary
- expose `FLOW_STD_MAX` threshold and skip fallback dodge when exceeded
- document new parameter in README
- test that high variance disables fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419eb865f08325b2063e344789fe1b