### PR TITLE
Add retention for flight view HTMLs

### DIFF
--- a/analysis/review_runs.py
+++ b/analysis/review_runs.py
@@ -16,6 +16,7 @@ if __package__ is None:
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from analysis.summarize_runs import summarize_log
+from uav.utils import retain_recent_views
 
 
 def ensure_visualization(log_path: str, html_path: str) -> None:
@@ -57,6 +58,7 @@ def main() -> None:
         html_name = f"flight_view_{timestamp}.html"
         html_path = os.path.join("analysis", html_name)
         ensure_visualization(path, html_path)
+        retain_recent_views("analysis")
 
     report_lines = ["log,frames,collisions,distance"]
     for path, frames, collisions, distance in results:

--- a/main.py
+++ b/main.py
@@ -31,7 +31,12 @@ def main():
     from uav.interface import exit_flag, start_gui
     from uav.perception import OpticalFlowTracker, FlowHistory
     from uav.navigation import Navigator
-    from uav.utils import get_drone_state, retain_recent_logs, should_flat_wall_dodge
+    from uav.utils import (
+        get_drone_state,
+        retain_recent_logs,
+        retain_recent_views,
+        should_flat_wall_dodge,
+    )
 
     # GUI parameter and status holders
     param_refs = {
@@ -371,6 +376,7 @@ def main():
                 "--output", html_output,
                 "--scale", "1.0"
             ])
+            retain_recent_views("analysis")
             print(f"✅ 3D visualisation saved to {html_output}")
         except Exception as e:
             print(f"⚠️ Visualization failed: {e}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import os
 import time
-from uav.utils import retain_recent_logs, should_flat_wall_dodge
+from uav.utils import retain_recent_logs, retain_recent_views, should_flat_wall_dodge
 
 
 def test_retain_recent_logs_keeps_latest(tmp_path):
@@ -31,4 +31,29 @@ def test_should_flat_wall_dodge_threshold():
     assert should_flat_wall_dodge(1.0, 0.2, 5, 5) is True
     # Not enough probe features -> should be False
     assert should_flat_wall_dodge(1.0, 0.2, 3, 5) is False
+
+
+def test_retain_recent_views_keeps_latest(tmp_path):
+    view_dir = tmp_path / "views"
+    view_dir.mkdir()
+
+    now = time.time()
+    for i in range(8):
+        p = view_dir / f"flight_view_{i}.html"
+        p.write_text("data")
+        mod_time = now - i
+        os.utime(p, (mod_time, mod_time))
+
+    (view_dir / "other.html").write_text("x")
+
+    retain_recent_views(str(view_dir), keep=5)
+    remaining = sorted(f.name for f in view_dir.iterdir())
+    expected = [f"flight_view_{i}.html" for i in range(5)] + ["other.html"]
+    assert remaining == expected
+
+
+def test_retain_recent_views_missing_dir(tmp_path):
+    missing = tmp_path / "missing"
+    retain_recent_views(str(missing), keep=5)
+    assert not missing.exists()
 

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -55,6 +55,31 @@ def retain_recent_logs(log_dir: str, keep: int = 5) -> None:
             pass
 
 
+def retain_recent_views(view_dir: str, keep: int = 5) -> None:
+    """Keep only the ``keep`` most recent flight view HTML files in *view_dir*.
+
+    Files matching ``flight_view_*.html`` are ordered by modification time.
+    Older files beyond the desired count are silently removed.
+    """
+
+    try:
+        views = [
+            os.path.join(view_dir, f)
+            for f in os.listdir(view_dir)
+            if f.startswith("flight_view_") and f.endswith(".html")
+        ]
+    except FileNotFoundError:
+        return
+
+    views.sort(key=os.path.getmtime, reverse=True)
+
+    for old_view in views[keep:]:
+        try:
+            os.remove(old_view)
+        except OSError:
+            pass
+
+
 def should_flat_wall_dodge(center_mag: float, probe_mag: float, probe_count: int,
                            min_probe_features: int = 5) -> bool:
     """Return True when probe flow is low but has enough features to


### PR DESCRIPTION
## Summary
- keep only the five most recent flight_view html files
- expose new `retain_recent_views` util
- clean up older visualizations in `main.py` and `analysis/review_runs.py`
- test the new retention helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419d11fddc83258b3fd887be8e53ec