### PR TITLE
Limit flight view history to five files

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -120,6 +120,9 @@ python analysis/visualize_flight.py --log flow_logs/full_log_XXXX.csv --output a
 Open the resulting HTML file in your browser to explore the flight path
 interactively.
 
+Only the five most recent `flight_view_*.html` files are retained in the
+`analysis/` directory. Older visualizations are removed automatically.
+
 ## Future Improvements
 
 * Add SLAM integration

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,5 +1,6 @@
 """Analysis utilities for reviewing UAV runs."""
 
 from .summarize_runs import summarize_log
+from .utils import retain_recent_views
 
-__all__ = ["summarize_log"]
+__all__ = ["summarize_log", "retain_recent_views"]

--- a/analysis/review_runs.py
+++ b/analysis/review_runs.py
@@ -16,6 +16,7 @@ if __package__ is None:
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from analysis.summarize_runs import summarize_log
+from analysis.utils import retain_recent_views
 
 
 def ensure_visualization(log_path: str, html_path: str) -> None:
@@ -57,6 +58,7 @@ def main() -> None:
         html_name = f"flight_view_{timestamp}.html"
         html_path = os.path.join("analysis", html_name)
         ensure_visualization(path, html_path)
+        retain_recent_views("analysis")
 
     report_lines = ["log,frames,collisions,distance"]
     for path, frames, collisions, distance in results:

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,0 +1,29 @@
+import os
+
+
+def retain_recent_views(view_dir: str, keep: int = 5) -> None:
+    """Keep only the ``keep`` most recent ``flight_view_*.html`` files.
+
+    Parameters
+    ----------
+    view_dir : str
+        Directory containing the generated HTML files.
+    keep : int, optional
+        Number of recent files to preserve. Older files are removed.
+    """
+    try:
+        views = [
+            os.path.join(view_dir, f)
+            for f in os.listdir(view_dir)
+            if f.startswith("flight_view_") and f.endswith(".html")
+        ]
+    except FileNotFoundError:
+        return
+
+    views.sort(key=os.path.getmtime, reverse=True)
+
+    for old_view in views[keep:]:
+        try:
+            os.remove(old_view)
+        except OSError:
+            pass

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ def main():
     from uav.perception import OpticalFlowTracker, FlowHistory
     from uav.navigation import Navigator
     from uav.utils import get_drone_state, retain_recent_logs, should_flat_wall_dodge
+    from analysis.utils import retain_recent_views
 
     # GUI parameter and status holders
     param_refs = {
@@ -373,6 +374,7 @@ def main():
                 "--scale", "1.0"
             ])
             print(f"✅ 3D visualisation saved to {html_output}")
+            retain_recent_views("analysis")
         except Exception as e:
             print(f"⚠️ Visualization failed: {e}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import time
 from uav.utils import retain_recent_logs, should_flat_wall_dodge
+from analysis.utils import retain_recent_views
 
 
 def test_retain_recent_logs_keeps_latest(tmp_path):
@@ -36,4 +37,26 @@ def test_should_flat_wall_dodge_threshold():
 def test_should_flat_wall_dodge_flow_std_limit():
     # Excessive variance should disable the fallback dodge
     assert should_flat_wall_dodge(1.0, 0.2, 5, 5, flow_std=50.0) is False
+
+
+def test_retain_recent_views_keeps_latest(tmp_path):
+    view_dir = tmp_path / "views"
+    view_dir.mkdir()
+
+    now = time.time()
+    for i in range(6):
+        p = view_dir / f"flight_view_{i}.html"
+        p.write_text("data")
+        mod_time = now - i
+        os.utime(p, (mod_time, mod_time))
+
+    retain_recent_views(str(view_dir), keep=5)
+    remaining = sorted(f.name for f in view_dir.iterdir())
+    assert remaining == [f"flight_view_{i}.html" for i in range(5)]
+
+
+def test_retain_recent_views_missing_dir(tmp_path):
+    missing = tmp_path / "missing"
+    retain_recent_views(str(missing), keep=5)
+    assert not missing.exists()
 


### PR DESCRIPTION
## Summary
- clean up old flight visualization files with `retain_recent_views`
- call `retain_recent_views` after generating new HTMLs
- update README with retention policy
- test retention logic

## Testing
- `pip install opencv-python msgpack-rpc-python msgpack pandas plotly scipy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a09caf788325a2c20718a34a9a0a