### PR TITLE
Add configurable probe height for flow mask

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import os
 import time
-from uav.utils import retain_recent_logs
+from uav.utils import retain_recent_logs, compute_probe_mask, DEFAULT_PROBE_HEIGHT
 
 
 def test_retain_recent_logs_keeps_latest(tmp_path):
@@ -25,4 +25,19 @@ def test_retain_recent_logs_missing_dir(tmp_path):
     missing = tmp_path / "missing"
     retain_recent_logs(str(missing), keep=3)
     assert not missing.exists()
+
+
+def test_compute_probe_mask_default_equivalent():
+    y_coords = [0, 50, 120, 170]
+    mask = list(compute_probe_mask(y_coords, 300, DEFAULT_PROBE_HEIGHT))
+    expected = [y < 300 // 3 for y in y_coords]
+    assert mask == expected
+
+
+def test_compute_probe_mask_custom_fraction():
+    y_coords = [0, 140, 160, 260]
+    mask = list(compute_probe_mask(y_coords, 400, 0.5))
+    expected_threshold = int(400 * 0.5 + 0.5)
+    expected = [y < expected_threshold for y in y_coords]
+    assert mask == expected
 

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -53,3 +53,23 @@ def retain_recent_logs(log_dir: str, keep: int = 5) -> None:
             os.remove(old_log)
         except OSError:
             pass
+
+
+# === Optical Flow Helpers ===
+
+# Default fraction of the image height used for the "probe" region when
+# evaluating optical flow.  This matches the previous behaviour of using
+# the top third of the frame.
+DEFAULT_PROBE_HEIGHT = 1 / 3
+
+
+def compute_probe_mask(y_coords, height: int, fraction: float = DEFAULT_PROBE_HEIGHT):
+    """Return a boolean mask selecting coordinates within the probe region.
+
+    The mask spans ``fraction`` of the frame starting from the top.  ``y_coords``
+    can be any iterable of y pixel values.  The function avoids numpy
+    vectorisation so that tests work with the minimal numpy stub.
+    """
+
+    threshold = int(height * fraction + 0.5)
+    return np.array([float(y) < threshold for y in y_coords])


### PR DESCRIPTION
## Summary
- make probe flow band height configurable
- compute mask using helper in `uav.utils`
- expose a `--probe-height` CLI option
- test default and custom mask logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841979e70b483259a4a8a5e6352faf6