### PR TITLE
Refactor log/view cleanup with shared helper

### DIFF
--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,29 +1,38 @@
 import os
+import fnmatch
 
 
-def retain_recent_views(view_dir: str, keep: int = 5) -> None:
-    """Keep only the ``keep`` most recent ``flight_view_*.html`` files.
+def retain_recent_files(dir_path: str, pattern: str, keep: int = 5) -> None:
+    """Keep only the ``keep`` most recent files matching ``pattern``.
 
     Parameters
     ----------
-    view_dir : str
-        Directory containing the generated HTML files.
+    dir_path : str
+        Directory to search for files.
+    pattern : str
+        Glob pattern used to select files within ``dir_path``.
     keep : int, optional
         Number of recent files to preserve. Older files are removed.
     """
     try:
-        views = [
-            os.path.join(view_dir, f)
-            for f in os.listdir(view_dir)
-            if f.startswith("flight_view_") and f.endswith(".html")
+        files = [
+            os.path.join(dir_path, f)
+            for f in os.listdir(dir_path)
+            if fnmatch.fnmatch(f, pattern)
         ]
     except FileNotFoundError:
         return
 
-    views.sort(key=os.path.getmtime, reverse=True)
+    files.sort(key=os.path.getmtime, reverse=True)
 
-    for old_view in views[keep:]:
+    for old_file in files[keep:]:
         try:
-            os.remove(old_view)
+            os.remove(old_file)
         except OSError:
             pass
+
+
+def retain_recent_views(view_dir: str, keep: int = 5) -> None:
+    """Keep only the ``keep`` most recent ``flight_view_*.html`` files."""
+
+    retain_recent_files(view_dir, "flight_view_*.html", keep)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,12 @@ def allclose(a, b, tol=1e-8):
 
 numpy_stub = types.SimpleNamespace(array=array, allclose=allclose)
 
-# Register stub if numpy is missing
-if 'numpy' not in sys.modules:
+# Register stub if numpy is not installed
+import importlib.util
+if importlib.util.find_spec('numpy') is None:
     sys.modules['numpy'] = numpy_stub
 # Minimal cv2 stub for environments without OpenCV
-if "cv2" not in sys.modules:
+if importlib.util.find_spec('cv2') is None:
     cv2_stub = types.SimpleNamespace(
         createCLAHE=lambda **kwargs: types.SimpleNamespace(apply=lambda img: img),
         goodFeaturesToTrack=lambda *a, **k: None,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import time
 from uav.utils import retain_recent_logs, should_flat_wall_dodge
-from analysis.utils import retain_recent_views
+from analysis.utils import retain_recent_views, retain_recent_files
 
 
 def test_retain_recent_logs_keeps_latest(tmp_path):
@@ -58,5 +58,27 @@ def test_retain_recent_views_keeps_latest(tmp_path):
 def test_retain_recent_views_missing_dir(tmp_path):
     missing = tmp_path / "missing"
     retain_recent_views(str(missing), keep=5)
+    assert not missing.exists()
+
+
+def test_retain_recent_files_keeps_latest(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    now = time.time()
+    for i in range(4):
+        p = data_dir / f"file_{i}.txt"
+        p.write_text("data")
+        mod_time = now - i
+        os.utime(p, (mod_time, mod_time))
+
+    retain_recent_files(str(data_dir), "*.txt", keep=2)
+    remaining = sorted(f.name for f in data_dir.iterdir())
+    assert remaining == ["file_0.txt", "file_1.txt"]
+
+
+def test_retain_recent_files_missing_dir(tmp_path):
+    missing = tmp_path / "none"
+    retain_recent_files(str(missing), "*.txt", keep=2)
     assert not missing.exists()
 

--- a/uav/utils.py
+++ b/uav/utils.py
@@ -5,6 +5,7 @@ import cv2
 import numpy as np
 import airsim
 import os
+from analysis.utils import retain_recent_files
 
 # Maximum acceptable standard deviation of optical flow magnitudes. When the
 # measured value exceeds this threshold the flow is considered unreliable.
@@ -35,28 +36,9 @@ def get_drone_state(client):
 
 
 def retain_recent_logs(log_dir: str, keep: int = 5) -> None:
-    """Keep only the `keep` most recent log files in *log_dir*.
+    """Keep only the ``keep`` most recent ``.csv`` log files."""
 
-    Files are ordered by modification time. Older files beyond the
-    desired count are silently removed.
-    """
-
-    try:
-        logs = [
-            os.path.join(log_dir, f)
-            for f in os.listdir(log_dir)
-            if f.endswith(".csv")
-        ]
-    except FileNotFoundError:
-        return
-
-    logs.sort(key=os.path.getmtime, reverse=True)
-
-    for old_log in logs[keep:]:
-        try:
-            os.remove(old_log)
-        except OSError:
-            pass
+    retain_recent_files(log_dir, "*.csv", keep)
 
 
 def should_flat_wall_dodge(center_mag: float, probe_mag: float, probe_count: int,


### PR DESCRIPTION
## Summary
- add new `retain_recent_files` helper for removing old files by pattern
- refactor log and view cleanup to use the helper
- adjust stubs to only load if packages are missing
- expand tests to cover the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f19f86a48325b89add34912eea8f