### PR TITLE
Make Navigator commands async

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,6 +127,15 @@ def main():
         while not exit_flag.is_set():
             frame_count += 1
             time_now = time.time()  # <-- Add this line
+
+            if navigator.motion_future:
+                if getattr(navigator.motion_future, "_set_flag", False):
+                    navigator.motion_future = None
+                    if navigator.dodging and not navigator.settling:
+                        navigator.settling = True
+                        navigator.settle_end_time = time_now + 2.0
+                else:
+                    continue
             # Handle settle phase after dodge
             if navigator.settling:
                 if time_now < navigator.settle_end_time:

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -7,6 +7,7 @@ from uav.navigation import Navigator
 class DummyFuture:
     def __init__(self):
         self.join_called = False
+        self._set_flag = True
 
     def join(self):
         self.join_called = True
@@ -41,7 +42,8 @@ def test_brake_updates_flags_and_calls():
     name, args, kwargs, fut = client.calls[-1]
     assert name == 'moveByVelocityAsync'
     assert args == (0, 0, 0, 1)
-    assert fut.join_called is True
+    assert fut.join_called is False
+    assert nav.motion_future is fut
 
 
 def test_dodge_left_sets_flags_and_calls():
@@ -60,8 +62,9 @@ def test_dodge_left_sets_flags_and_calls():
     assert call2.args == (0.3, -1.0, 0, 2.0)
     fut1 = client.calls[0][3]
     fut2 = client.calls[1][3]
-    assert fut1.join_called is True
-    assert fut2.join_called is True
+    assert fut1.join_called is False
+    assert fut2.join_called is False
+    assert nav.motion_future is fut2
 
 
 def test_ambiguous_dodge_forces_lower_flow_side():
@@ -74,6 +77,7 @@ def test_ambiguous_dodge_forces_lower_flow_side():
     assert call1.args == (0, 0, 0, 0.2)
     call2 = client.moveByVelocityBodyFrameAsync.call_args_list[1]
     assert call2.args == (0.0, -1.0, 0, 2.0)
+    assert nav.motion_future is client.calls[1][3]
 
 
 def test_resume_forward_clears_flags_and_calls():
@@ -104,7 +108,8 @@ def test_nudge_updates_time_and_calls():
     name, args, kwargs, fut = client.calls[-1]
     assert name == 'moveByVelocityAsync'
     assert args == (0.5, 0, 0, 1)
-    assert fut.join_called is True
+    assert fut.join_called is False
+    assert nav.motion_future is fut
 
 
 def test_reinforce_updates_time_and_calls():

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -12,6 +12,7 @@ class Navigator:
         self.braked = False
         self.dodging = False
         self.settling = False
+        self.motion_future = None
         self.last_movement_time = time.time()
         self.grace_period_end_time = 0
         self.settle_end_time = 0
@@ -29,7 +30,7 @@ class Navigator:
     def brake(self):
         """Stop the drone immediately."""
         print("🛑 Braking")
-        self.client.moveByVelocityAsync(0, 0, 0, 1).join()
+        self.motion_future = self.client.moveByVelocityAsync(0, 0, 0, 1)
         self.braked = True
         return "brake"
 
@@ -58,23 +59,22 @@ class Navigator:
         forward_speed = 0.0 if smooth_C > 1.0 else 0.3
 
         # Stop briefly
-        self.client.moveByVelocityBodyFrameAsync(0, 0, 0, 0.2).join()
+        self.client.moveByVelocityBodyFrameAsync(0, 0, 0, 0.2)
 
         print(
             f"🔀 Dodging {direction} (strength {strength:.1f}, "
             f"forward {forward_speed:.1f})"
         )
-        self.client.moveByVelocityBodyFrameAsync(
+        self.motion_future = self.client.moveByVelocityBodyFrameAsync(
             forward_speed,
             lateral * strength,
             0,
             duration
-        ).join()
+        )
 
         self.dodging = True
         self.braked = False
-        self.settling = True
-        self.settle_end_time = time.time() + 2.0
+        self.settling = False
         self.last_movement_time = time.time()
         return f"dodge_{direction}"
 
@@ -97,28 +97,28 @@ class Navigator:
     def blind_forward(self):
         """Move forward when no features are detected."""
         print("⚠️ No features — continuing blind forward motion")
-        self.client.moveByVelocityAsync(
+        self.motion_future = self.client.moveByVelocityAsync(
             2,
             0,
             0,
             duration=2,
             drivetrain=airsim.DrivetrainType.ForwardOnly,
             yaw_mode=airsim.YawMode(False, 0),
-        ).join()
+        )
         self.last_movement_time = time.time()
         return "blind_forward"
 
     def nudge(self):
         """Gently push the drone forward when stalled."""
         print("⚠️ Low flow + zero velocity — nudging forward")
-        self.client.moveByVelocityAsync(0.5, 0, 0, 1).join()
+        self.motion_future = self.client.moveByVelocityAsync(0.5, 0, 0, 1)
         self.last_movement_time = time.time()
         return "nudge"
 
     def reinforce(self):
         """Reissue the forward command to reinforce motion."""
         print("🔁 Reinforcing forward motion")
-        self.client.moveByVelocityAsync(
+        self.motion_future = self.client.moveByVelocityAsync(
             2,
             0,
             0,
@@ -132,6 +132,6 @@ class Navigator:
     def timeout_recover(self):
         """Move slowly forward after a command timeout."""
         print("⏳ Timeout — forcing recovery motion")
-        self.client.moveByVelocityAsync(0.5, 0, 0, 1).join()
+        self.motion_future = self.client.moveByVelocityAsync(0.5, 0, 0, 1)
         self.last_movement_time = time.time()
         return "timeout_nudge"


### PR DESCRIPTION
## Summary
- store motion future on Navigator
- call `moveByVelocity*Async` without joining
- track future completion in main loop
- update navigator unit tests for async calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842fcfd7cdc83258e5ebc00d95d6f6a