### PR TITLE
Fix resume_forward timing

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,7 +296,13 @@ def main():
 
                 # === Recovery / Maintenance States (always allowed)
                 if state_str == "none":
-                    if (navigator.braked or navigator.dodging) and smooth_C < 10 and smooth_L < 10 and smooth_R < 10:
+                    if (
+                        (navigator.braked or navigator.dodging)
+                        and smooth_C < 10
+                        and smooth_L < 10
+                        and smooth_R < 10
+                        and time_now >= navigator.grace_period_end_time
+                    ):
                         state_str = navigator.resume_forward()
                     elif not navigator.braked and not navigator.dodging and time_now - navigator.last_movement_time > 2:
                         state_str = navigator.reinforce()

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -131,3 +131,22 @@ def test_dodge_settle_duration_short():
     nav.dodge(0, 0, 20)
     assert nav.settling is True
     assert nav.settle_end_time - before <= 0.5
+
+
+def test_resume_forward_not_called_during_grace():
+    client = DummyClient()
+    nav = Navigator(client)
+    nav.dodging = True
+    nav.grace_period_end_time = time.time() + 1.0
+    nav.resume_forward = mock.MagicMock()
+    time_now = time.time()
+    smooth_L = smooth_C = smooth_R = 0
+    if (
+        (nav.braked or nav.dodging)
+        and smooth_C < 10
+        and smooth_L < 10
+        and smooth_R < 10
+        and time_now >= nav.grace_period_end_time
+    ):
+        nav.resume_forward()
+    nav.resume_forward.assert_not_called()


### PR DESCRIPTION
## Summary
- avoid calling `navigator.resume_forward()` before the dodge grace period expires
- test that resume-forward does not trigger during grace period

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684310c357448325a45a6a9261473f2c