### PR TITLE
Reduce forward speed during dodges

### DIFF
--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -58,7 +58,7 @@ def test_dodge_left_sets_flags_and_calls():
     call1 = client.moveByVelocityBodyFrameAsync.call_args_list[0]
     assert call1.args == (0, 0, 0, 0.2)
     call2 = client.moveByVelocityBodyFrameAsync.call_args_list[1]
-    assert call2.args == (0.3, -1.0, 0, 2.0)
+    assert call2.args == (0.1, -1.0, 0, 2.0)
     fut1 = client.calls[0][3]
     fut2 = client.calls[1][3]
     assert fut1.join_called is False

--- a/uav/navigation.py
+++ b/uav/navigation.py
@@ -55,7 +55,8 @@ class Navigator:
 
         lateral = 1.0 if direction == "right" else -1.0
         strength = 0.5 if max(smooth_L, smooth_R) > 100 else 1.0
-        forward_speed = 0.0 if smooth_C > 1.0 else 0.3
+        # Reduce forward motion during the dodge to prioritize lateral movement
+        forward_speed = 0.0 if smooth_C > 1.0 else 0.1
 
         # Stop briefly
         self.client.moveByVelocityBodyFrameAsync(0, 0, 0, 0.2)


### PR DESCRIPTION
## Summary
- tone down forward motion while dodging
- update navigator tests for new forward speed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843215fe98c832589212cad4645d33f