### PR TITLE
Use shared FLOW_STD_MAX constant

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ import argparse
 from queue import Queue
 from threading import Thread
 
+from uav.utils import FLOW_STD_MAX
+
 # Default path to the Unreal Engine simulator used during development
 DEFAULT_UE4_PATH = r"C:\Users\newso\Documents\AirSimExperiments\BlocksBuild\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe"
 
@@ -82,7 +84,6 @@ def main():
     GOAL_X = 29  # distance from start in AirSim coordinates
     GOAL_RADIUS = 1.0  # meters
     MIN_PROBE_FEATURES = 5
-    FLOW_STD_MAX = 10.0
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     os.makedirs("flow_logs", exist_ok=True)
     log_file = open(f"flow_logs/full_log_{timestamp}.csv", 'w')

--- a/tests/test_flow_std_max.py
+++ b/tests/test_flow_std_max.py
@@ -1,0 +1,19 @@
+import importlib
+import sys
+import types
+
+import tests.conftest  # ensure stubs loaded for numpy, cv2, etc.
+from uav import utils
+
+
+def test_flow_std_max_matches_utils(monkeypatch):
+    # Provide minimal airsim stub so main imports cleanly
+    airsim_stub = types.SimpleNamespace(ImageRequest=object, ImageType=object)
+    monkeypatch.setitem(sys.modules, 'airsim', airsim_stub)
+    # Stub pandas if missing to satisfy analysis imports
+    if 'pandas' not in sys.modules:
+        monkeypatch.setitem(sys.modules, 'pandas', types.SimpleNamespace())
+    main = importlib.import_module('main')
+    importlib.reload(main)
+    assert main.FLOW_STD_MAX == utils.FLOW_STD_MAX
+


### PR DESCRIPTION
## Summary
- use FLOW_STD_MAX from `uav.utils` instead of defining it in `main.py`
- check for consistent value in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441dae3f788325aa819ad4fc2be03e