### PR TITLE
Fix log retention logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -470,6 +470,7 @@ def main():
             ])
             print(f"✅ 3D visualisation saved to {html_output}")
             retain_recent_views("analysis")
+            retain_recent_logs("flow_logs")
         except Exception as e:
             print(f"⚠️ Visualization failed: {e}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,18 +8,16 @@ def test_retain_recent_logs_keeps_latest(tmp_path):
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
 
-    now = time.time()
-    paths = []
-    for i in range(5):
-        p = log_dir / f"log_{i}.csv"
+    for i in range(6):
+        ts = f"20240101_00000{i}"
+        p = log_dir / f"full_log_{ts}.csv"
         p.write_text("data")
-        mod_time = now - i
-        os.utime(p, (mod_time, mod_time))
-        paths.append(p)
 
     retain_recent_logs(str(log_dir), keep=3)
     remaining = sorted(f.name for f in log_dir.iterdir())
-    assert remaining == ["log_0.csv", "log_1.csv", "log_2.csv"]
+    assert remaining == [
+        f"full_log_20240101_00000{i}.csv" for i in range(3, 6)
+    ]
 
 
 def test_retain_recent_logs_missing_dir(tmp_path):


### PR DESCRIPTION
## Summary
- ensure only latest flight logs are kept by parsing timestamps from filenames
- purge old logs when generating the flight view
- adapt tests for new log retention behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68441ddfea2c8325a5e553b01dd6847b