### PR TITLE
Initialize optical flow tracker in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from queue import Queue
 from threading import Thread
 from multiprocessing import Process, Queue as MPQueue
 
+from uav.perception import OpticalFlowTracker
+
 from uav.utils import FLOW_STD_MAX
 
 # Default path to the Unreal Engine simulator used during development
@@ -152,8 +154,11 @@ def main():
 
     # Tune feature detection to pick up more corners even on smooth surfaces
     feature_params = dict(maxCorners=150, qualityLevel=0.05, minDistance=5, blockSize=5)
+
     lk_params = dict(winSize=(15, 15), maxLevel=2,
                      criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 0.03))
+
+    tracker = OpticalFlowTracker(lk_params, feature_params)
 
     flow_history = FlowHistory()
     navigator = Navigator(client)


### PR DESCRIPTION
## Summary
- import `OpticalFlowTracker` at module level
- create `tracker` instance in `main()` before processing frames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844609bc1ec8325bcf131eb89e5bb4e